### PR TITLE
fix(unified-theme): remove trailing comma in package.json

### DIFF
--- a/src/unified-theme/package.json
+++ b/src/unified-theme/package.json
@@ -4,7 +4,7 @@
   "description": "Assets for the Elevate theme",
   "scripts": {
     "start": "hs-cms-dev-server .",
-    "generate-tmp-json-for-translations": "jsx-module-fields-to-fields-json",
+    "generate-tmp-json-for-translations": "jsx-module-fields-to-fields-json"
   },
   "type": "module",
   "keywords": [],


### PR DESCRIPTION
The package.json in src/unified-theme had a trailing comma after the last script. This caused `npm` to throw an EJSONPARSE error when running `npm run start`.

Removing the trailing comma makes the JSON valid and allows the development server to run correctly.