### PR TITLE
Update cms elevate theme

### DIFF
--- a/src/unified-theme/templates/blog-detail.hubl.html
+++ b/src/unified-theme/templates/blog-detail.hubl.html
@@ -104,7 +104,7 @@
       <a class="hs-elevate-card--recent-post__link" href="{{ post.absolute_url|escape_url }}">
         {% if group.use_featured_image_in_summary %}
           <div class="hs-elevate-card--recent-post__image-container">
-            <img src={{ post.featured_image|escape_url }} alt="{{ post.featured_image_alt|escape_attr }}" width="{{ post.featured_image_width|escape_attr }}" height="{{ post.featured_image_height|escape_attr }}">
+            <img src="{{ post.featured_image|escape_url }}" alt="{{ post.featured_image_alt_text|escape_attr }}" width="{{ post.featured_image_width|escape_attr }}" height="{{ post.featured_image_height|escape_attr }}">
           </div>
         {% endif %}
 


### PR DESCRIPTION
##  Description
                                                                                                                           
  Fixes two bugs in the blog detail template's recent posts section.

###  Bug Fix: Recent Blog Posts: Featured Image

  In `src/unified-theme/templates/blog-detail.hubl.html`, these issues were corrected in the recent posts card image tag:

  - Missing quotes on src attribute — The src attribute value was unquoted (`src={{ ... }}`), which is invalid HTML. It now  correctly uses `src="{{ ... }}"`.
  - Wrong alt text variable — The alt attribute was referencing `post.featured_image_alt`, which does not exist. It now uses  the correct variable `post.featured_image_alt_text`.
