### PR TITLE
3/18 Weekly update cms elevate theme

### DIFF
--- a/src/unified-theme/components/modules/ImageAndText/image-and-text.module.css
+++ b/src/unified-theme/components/modules/ImageAndText/image-and-text.module.css
@@ -1,13 +1,14 @@
 .hs-elevate-image-and-text {
   display: flex;
   flex-direction: column;
-  align-items: var(--hsElevate--imageAndText__alignItems, center);
+  align-items: stretch;
   justify-content: space-between;
   -moz-column-gap: var(--hsElevate--spacing--80, 80px);
   column-gap: var(--hsElevate--spacing--80, 80px);
 
   @media (width >= 767px) {
     flex-direction: row;
+    align-items: var(--hsElevate--imageAndText__alignItems, center);
   }
 }
 


### PR DESCRIPTION
Updated mobile styles to use align-items: stretch, allowing containers to expand to full width. This ensures images and text span the full width of the page in most cases, improving overall layout consistency.