### PR TITLE
Pull latest updates from update-cms-elevate-theme

### DIFF
--- a/src/unified-theme/components/modules/SocialFollow/index.tsx
+++ b/src/unified-theme/components/modules/SocialFollow/index.tsx
@@ -3,7 +3,7 @@ import { Icon } from '@hubspot/cms-components';
 import socialIconSvg from './assets/social-follow.svg';
 import { IconFieldType, LinkFieldType, TextFieldType, AlignmentFieldType, BooleanFieldType } from '@hubspot/cms-components/fields';
 import { StandardSizeType, ButtonStyleType } from '../../types/fields.js';
-import { getLinkFieldRel, getLinkFieldTarget } from '../../utils/content-fields.js';
+import { getLinkFieldHref, getLinkFieldRel, getLinkFieldTarget } from '../../utils/content-fields.js';
 import { ButtonStyleFieldLibraryType } from '../../fieldLibrary/ButtonStyle/types.js';
 import { getAlignmentFieldCss } from '../../utils/style-fields.js';
 import styles from './social-follow.module.css';
@@ -87,9 +87,7 @@ function generateIconShapeCssVars(iconShapeField: ShapeOption): CSSPropertiesMap
     circle: 'var(--hsElevate-circle)',
   };
 
-  return {
-    '--hsElevate--socialFollowIcon__shape': iconShapeMap[iconShapeField],
-  };
+  return { '--hsElevate--socialFollowIcon__shape': iconShapeMap[iconShapeField] };
 }
 
 function generateIconGapCssVars(iconGapField: SizeOption): CSSPropertiesMap {
@@ -99,17 +97,13 @@ function generateIconGapCssVars(iconGapField: SizeOption): CSSPropertiesMap {
     large: 'var(--hsElevate--spacing--48, 48px)',
   };
 
-  return {
-    '--hsElevate--socialFollowIcon__gap': iconGapMap[iconGapField],
-  };
+  return { '--hsElevate--socialFollowIcon__gap': iconGapMap[iconGapField] };
 }
 
 function generateAlignmentCssVars(alignmentField: AlignmentFieldType['default']): CSSPropertiesMap {
   const alignmentCss = getAlignmentFieldCss(alignmentField);
 
-  return {
-    '--hsElevate--socialFollow__justifyContent': alignmentCss.justifyContent || 'flex-start',
-  };
+  return { '--hsElevate--socialFollow__justifyContent': alignmentCss.justifyContent || 'flex-start' };
 }
 
 function generateButtonStyles(buttonStyleVariant: ButtonStyleType): CSSPropertiesMap {
@@ -318,7 +312,7 @@ export const Component = (props: SocialFollowProps) => {
             key={index}
             rel={getLinkFieldRel(link)}
             target={getLinkFieldTarget(link)}
-            href={link.url.href}
+            href={getLinkFieldHref(link)}
             aria-label={socialIcon.aria_label}
           >
             <Icon className={swm('hs-elevate-social-follow__icon')} purpose="DECORATIVE" fieldPath={iconFieldPath} />

--- a/src/unified-theme/components/utils/content-fields.ts
+++ b/src/unified-theme/components/utils/content-fields.ts
@@ -1,18 +1,19 @@
 import { LinkFieldType } from '@hubspot/cms-components/fields';
 
-
 // Links
 
 export function getLinkFieldHref(fieldValue: LinkFieldType['default']) {
-  if(!fieldValue || !fieldValue.url) return;
+  if (!fieldValue || !fieldValue.url) {
+    return;
+  }
 
   const linkHref = fieldValue.url.href;
   const linkType = fieldValue.url.type;
 
   const hrefMap = {
-    "EMAIL_ADDRESS": `mailto:${linkHref}`,
-    "PAYMENT": `${linkHref}?referrer=CMS_MODULE_NEWTAB`,
-  }
+    EMAIL_ADDRESS: `mailto:${linkHref}`,
+    PAYMENT: `${linkHref}?referrer=CMS_MODULE_NEWTAB`,
+  };
 
   return hrefMap[linkType] || linkHref;
 }
@@ -29,7 +30,9 @@ export function getLinkFieldRel(fieldValue: LinkFieldType['default']) {
   return relValues.join(' ');
 }
 export function getLinkFieldTarget(fieldValue: LinkFieldType['default']): string {
-  if (!fieldValue) return '';
-  
+  if (!fieldValue) {
+    return '';
+  }
+
   return fieldValue.open_in_new_tab ? '_blank' : '';
 }


### PR DESCRIPTION
## Summary

Syncs this branch with the latest upstream changes from `origin/update-cms-elevate-theme`.

## Modifications

- **`src/unified-theme/components/modules/SocialFollow/index.tsx`**: Use the new `getLinkFieldHref()` helper for the social link `href` instead of reading `link.url.href` directly, so special link types (email, payment) are handled correctly.
- **`src/unified-theme/components/modules/SocialFollow/index.tsx`**: Collapse three single-property `CSSPropertiesMap` return objects (`generateIconShapeCssVars`, `generateIconGapCssVars`, `generateAlignmentCssVars`) to one-line returns.
- **`src/unified-theme/components/utils/content-fields.ts`**: Reformat `getLinkFieldHref()` and `getLinkFieldTarget()` guard clauses to braced `if` statements, and unquote the `EMAIL_ADDRESS` / `PAYMENT` keys in the `hrefMap`.
